### PR TITLE
Enforce positive product prices

### DIFF
--- a/src/main/java/com/musinsa/product/service/ProductService.java
+++ b/src/main/java/com/musinsa/product/service/ProductService.java
@@ -145,9 +145,20 @@ public class ProductService {
         return result;
     }
 
-    // 모든 카테고리에 1개의 상품이 있는지 체크
+    // 모든 상품의 가격이 양수인지 검증
+    private void validateProductPrices(List<ProductDto> products) {
+        for (ProductDto pd : products) {
+            if (pd.getPrice() <= 0) {
+                log.error("가격이 0 이하인 상품 발견 - 카테고리: {}, 가격: {}", pd.getCategoryName(), pd.getPrice());
+                throw new ApiException("상품 가격은 0보다 커야 합니다.");
+            }
+        }
+    }
+
+    // 모든 카테고리에 1개의 상품이 있는지 체크 및 가격 검증
     private void checkAllCategoriesHasOneProduct(List<ProductDto> products) {
         log.debug("카테고리별 상품 개수 검증 시작");
+        validateProductPrices(products);
         List<Category> allCategories = categoryRepo.findAll();
         List<String> productCategories = products.stream()
                 .map(ProductDto::getCategoryName)
@@ -171,6 +182,8 @@ public class ProductService {
     // 상품 리스트를 받아 브랜드와 함께 저장
     private void saveProductsForBrand(Brand brand, List<ProductDto> products) {
         log.debug("브랜드 {}의 상품 저장 시작 - 상품 개수: {}", brand.getName(), products.size());
+        // 가격 검증 - 사전 검증 메서드를 신뢰하지만 재확인 차원에서 호출
+        validateProductPrices(products);
         List<Category> allCategories = categoryRepo.findAll();
         for (ProductDto pd : products) {
             Category cat = allCategories.stream()

--- a/src/test/java/com/musinsa/controller/ProductControllerTest.java
+++ b/src/test/java/com/musinsa/controller/ProductControllerTest.java
@@ -100,6 +100,30 @@ class ProductControllerTest {
     }
 
     @Test
+    @DisplayName("브랜드 및 상품 추가 실패 - 상품 가격 0 이하")
+    void addBrandWithProductsPriceFail() throws Exception {
+        BrandDto brandDto = new BrandDto();
+        brandDto.setName("PriceFail");
+        brandDto.setProducts(List.of(
+                new ProductDto("상의", -1000),
+                new ProductDto("아우터", 6000),
+                new ProductDto("바지", 4000),
+                new ProductDto("스니커즈", 9000),
+                new ProductDto("가방", 2000),
+                new ProductDto("모자", 1700),
+                new ProductDto("양말", 1800),
+                new ProductDto("액세서리", 2300)
+        ));
+
+        mockMvc.perform(post("/brand")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(brandDto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
     @DisplayName("브랜드 및 상품 수정 성공")
     void updateBrandWithProducts() throws Exception {
         // 먼저 브랜드를 생성


### PR DESCRIPTION
## Summary
- validate that product prices are positive
- apply validation before saving products
- test price validation on product creation

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6867f0411334832293b38f97bacd28a0